### PR TITLE
Changed Vagrant box to upgrade Ubuntu version from 18.04 to 20.04 LTS

### DIFF
--- a/oah-config.yml
+++ b/oah-config.yml
@@ -5,7 +5,7 @@ oah_env_name: oah-bes-vm
 oah_vm_gui: true
 # `vagrant_box` .
 #vagrant_box: OAH/ubuntu1404
-vagrant_box: "ubuntu/focal64"
+vagrant_box: "ubuntu/jammy64"
 vagrant_user: vagrant
 oah_env_user: vagrant
 oah_user: oahdev

--- a/oah-config.yml
+++ b/oah-config.yml
@@ -5,7 +5,7 @@ oah_env_name: oah-bes-vm
 oah_vm_gui: true
 # `vagrant_box` .
 #vagrant_box: OAH/ubuntu1404
-vagrant_box: "hashicorp/bionic64"
+vagrant_box: "ubuntu/focal64"
 vagrant_user: vagrant
 oah_env_user: vagrant
 oah_user: oahdev

--- a/oah-config.yml
+++ b/oah-config.yml
@@ -3,8 +3,6 @@
 oah_env_name: oah-bes-vm
 #GUI Flag
 oah_vm_gui: true
-# `vagrant_box` .
-#vagrant_box: OAH/ubuntu1404
 vagrant_box: "ubuntu/focal64"
 vagrant_user: vagrant
 oah_env_user: vagrant

--- a/oah-config.yml
+++ b/oah-config.yml
@@ -3,6 +3,8 @@
 oah_env_name: oah-bes-vm
 #GUI Flag
 oah_vm_gui: true
+# `vagrant_box` .
+#vagrant_box: OAH/ubuntu1404
 vagrant_box: "ubuntu/focal64"
 vagrant_user: vagrant
 oah_env_user: vagrant

--- a/oah-config.yml
+++ b/oah-config.yml
@@ -5,7 +5,7 @@ oah_env_name: oah-bes-vm
 oah_vm_gui: true
 # `vagrant_box` .
 #vagrant_box: OAH/ubuntu1404
-vagrant_box: "ubuntu/jammy64"
+vagrant_box: "ubuntu/focal64"
 vagrant_user: vagrant
 oah_env_user: vagrant
 oah_user: oahdev


### PR DESCRIPTION
https://github.com/Be-Secure/oah-bes-vm/issues/25

Changed vagrant box from hashicorp/bionic64 to ubuntu/focal64.
All the Ansible roles are working well on the updated Ubuntu LTS version.
